### PR TITLE
feat(Cargo.toml): remove unused mazzaroth-xdr dependency and update xdr-rs-serialize version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "itoa"
@@ -523,7 +523,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xdr-codegen"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "handlebars",
  "pest",
@@ -536,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "xdr-rs-serialize"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4bc1e5369f228d4fb05a58a64d03cf37f317712b3355e6ee2cc8cce431537ea"
+checksum = "d74e59c0da611180cb84c3a4bee415ad3104358bfae61a688a2167414b1770bd"
 dependencies = [
  "base64",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,17 +200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
-name = "mazzaroth-xdr"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551c080d1184f8f9ba47c0356a70d7f78f3a7754699a4a8330386f95c86b622"
-dependencies = [
- "json",
- "xdr-rs-serialize",
- "xdr-rs-serialize-derive",
-]
-
-[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,7 +526,6 @@ name = "xdr-codegen"
 version = "0.2.2"
 dependencies = [
  "handlebars",
- "mazzaroth-xdr",
  "pest",
  "pest_derive",
  "serde",
@@ -555,15 +543,4 @@ dependencies = [
  "base64",
  "hex",
  "json",
-]
-
-[[package]]
-name = "xdr-rs-serialize-derive"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01de1017ed1803d107d4a7e5b5bb653b5e40fc9fa020383d42ceb1fed7c7bb5d"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xdr-codegen"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "XDR code generation"
 license = "MIT"
@@ -12,7 +12,7 @@ keywords = ["xdr", "code", "generation"]
 exclude = ["test.x"]
 
 [dependencies]
-xdr-rs-serialize = "0.2.5"
+xdr-rs-serialize = "0.3.0"
 pest = "2.1.1"
 pest_derive = "2.1.0"
 structopt = "0.2.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ keywords = ["xdr", "code", "generation"]
 exclude = ["test.x"]
 
 [dependencies]
-mazzaroth-xdr = { branch = "develop", version = "0.2.5" }
-xdr-rs-serialize = { branch = "develop", version = "0.2.3" }
+xdr-rs-serialize = "0.2.5"
 pest = "2.1.1"
 pest_derive = "2.1.0"
 structopt = "0.2.15"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-extern crate mazzaroth_xdr;
 extern crate pest;
 extern crate structopt;
 extern crate xdr_rs_serialize;


### PR DESCRIPTION
# Description

- Update xdr-rs-serialize dependency.
- Removed unused mazzaroth-xdr dependency. 
- Also updated both to use version number only without branch tag in Cargo.toml.