### PR TITLE
feat(go): add MashalJSON and UnmarshalJSON functions for Union type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xdr-codegen"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "handlebars",
  "pest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xdr-codegen"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "XDR code generation"
 license = "MIT"


### PR DESCRIPTION
# Description

- bumped to Version v0.4.0 for next release.
- Fixed Namespace typo in generated go code.
- Add MarshalJSON and UnmarshalJSON functions to generated Unions.

To enable JSON Marshaling for XDR Objects in Go we must handle the special case of Unions where the JSON representation contains only `type` for the discriminant and `data` for the object.   This will now match the json encoding and decoding that has been implemented for Rust and JavaScript.

Example functions generated for the `Update` union within a Transaction in mazzaroth-xdr which has 3 different types:

```
// MarshalJSON implements json.Marshaler.
func (u Update) MarshalJSON() ([]byte, error) {
	temp := struct {
		Type int32       `json:"type"`
		Data interface{} `json:"data"`
	}{}

	temp.Type = int32(u.Type)
	temp.Data = ""
	switch u.Type {
	case UpdateTypeUNKNOWN:
	case UpdateTypeCONTRACT:
		temp.Data = u.Contract
	case UpdateTypeCONFIG:
		temp.Data = u.ChannelConfig
	case UpdateTypeACCOUNT:
		temp.Data = u.Account
	default:
		return nil, fmt.Errorf("invalid union type")
	}

	return json.Marshal(temp)
}

// UnmarshalJSON implements json.Unmarshaler.
func (u *Update) UnmarshalJSON(data []byte) error {
	temp := struct {
		Type int32 `json:"type"`
	}{}
	if err := json.Unmarshal(data, &temp); err != nil {
		return err
	}

	u.Type = UpdateType(temp.Type)
	switch u.Type {
	case UpdateTypeUNKNOWN:

	case UpdateTypeCONTRACT:
		response := struct {
			Contract Contract `json:"data"`
		}{}
		err := json.Unmarshal(data, &response)
		if err != nil {
			return err
		}
		u.Contract = &response.Contract

	case UpdateTypeCONFIG:
		response := struct {
			ChannelConfig ChannelConfig `json:"data"`
		}{}
		err := json.Unmarshal(data, &response)
		if err != nil {
			return err
		}
		u.ChannelConfig = &response.ChannelConfig

	case UpdateTypeACCOUNT:
		response := struct {
			Account AccountUpdate `json:"data"`
		}{}
		err := json.Unmarshal(data, &response)
		if err != nil {
			return err
		}
		u.Account = &response.Account

	default:
		return fmt.Errorf("invalid union type")
	}

	return nil
}
```