### PR TITLE
Fix(go): remove struct field pointer generation to fix binary marshal of XDR Structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,7 +445,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xdr-codegen"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "handlebars",
  "pest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xdr-codegen"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "XDR code generation"
 license = "MIT"

--- a/src/generator/go/mod.rs
+++ b/src/generator/go/mod.rs
@@ -556,4 +556,104 @@ mod tests {
         assert!(generated_code.contains("Hyper_test int64 `json:\"hyper_test,string\"`"));
         assert!(generated_code.contains("Unsigned_hyper_test uint64 `json:\"unsigned_hyper_test,string\"`"));
     }
+
+    #[test]
+    fn typedef_union() {
+        let input_test = vec![Namespace {
+            enums: Vec::new(),
+            structs: vec![Struct {
+                name: String::from("TestStruct"),
+                props: vec![Def {
+                    name: String::from("stringTest"),
+                    type_name: String::from("string"),
+                    array_size: 0,
+                    fixed_array: false,
+                    tag: String::new(),
+                }],
+                tag: String::new(),
+            }],
+            typedefs: Vec::new(),
+            unions: vec![Union {
+                name: String::from("TestUnion"),
+                switch: Switch {
+                    enum_name: String::from("Type"),
+                    enum_type: String::from("enumType"),
+                    cases: vec![
+                        Case {
+                            value: String::from("ONE"),
+                            ret_type: Def {
+                                name: String::from("stringTest"),
+                                type_name: String::from("string"),
+                                array_size: 0,
+                                fixed_array: false,
+                                tag: String::new(),
+                            },
+                        },
+                        Case {
+                            value: String::from("TWO"),
+                            ret_type: Def {
+                                name: String::from("structTest"),
+                                type_name: String::from("TestStruct"),
+                                array_size: 0,
+                                fixed_array: false,
+                                tag: String::new(),
+                            },
+                        },
+                        Case {
+                            value: String::from("THREE"),
+                            ret_type: Def {
+                                name: String::from("arrayTest"),
+                                type_name: String::from("int"),
+                                array_size: 5,
+                                fixed_array: false,
+                                tag: String::new(),
+                            },
+                        },
+                        Case {
+                            value: String::from("FOUR"),
+                            ret_type: Def {
+                                name: String::from("arrayStructTest"),
+                                type_name: String::from("TestStruct"),
+                                array_size: 5,
+                                fixed_array: false,
+                                tag: String::new(),
+                            },
+                        },
+                    ],
+                },
+            }],
+            name: String::from("test"),
+        }];
+        let res = GoGenerator {}.code(input_test);
+        assert!(res.is_ok());
+        let generated_code = res.unwrap();
+        println!("{}", generated_code);
+        assert!(generated_code.contains("StringTest *string"));
+        assert!(generated_code.contains("result = *u.StringTest"));
+        assert!(generated_code.contains("u.StringTest = &response.StringTest"));
+        assert!(generated_code.contains("func (u TestUnion) MustStringTest() string {"));
+        assert!(generated_code.contains("func (u TestUnion) GetStringTest() (result string, ok bool) {"));
+        assert!(generated_code.contains("result.StringTest = &tv"));
+
+        assert!(generated_code.contains("StructTest *TestStruct"));
+        assert!(generated_code.contains("result = *u.StructTest"));
+        assert!(generated_code.contains("u.StructTest = &response.StructTest"));
+        assert!(generated_code.contains("func (u TestUnion) MustStructTest() TestStruct {"));
+        assert!(generated_code.contains("func (u TestUnion) GetStructTest() (result TestStruct, ok bool) {"));
+        assert!(generated_code.contains("result.StructTest = &tv"));
+
+        assert!(generated_code.contains("ArrayTest []int32"));
+        assert!(generated_code.contains("result = *u.ArrayTest"));
+        assert!(generated_code.contains("u.ArrayTest = &response.ArrayTest"));
+        assert!(generated_code.contains("func (u TestUnion) MustArrayTest() []int32 {"));
+        assert!(generated_code.contains("func (u TestUnion) GetArrayTest() (result []int32, ok bool) {"));
+        assert!(generated_code.contains("result.ArrayTest = &tv"));
+
+        assert!(generated_code.contains("ArrayStructTest []TestStruct"));
+        assert!(generated_code.contains("result = *u.ArrayStructTest"));
+        assert!(generated_code.contains("u.ArrayStructTest = &response.ArrayStructTest"));
+        assert!(generated_code.contains("func (u TestUnion) MustArrayStructTest() []TestStruct {"));
+        assert!(generated_code.contains("func (u TestUnion) GetArrayStructTest() (result []TestStruct, ok bool) {"));
+        assert!(generated_code.contains("result.ArrayStructTest = &tv"));
+    }
 }

--- a/src/generator/go/mod.rs
+++ b/src/generator/go/mod.rs
@@ -558,7 +558,7 @@ mod tests {
     }
 
     #[test]
-    fn typedef_union() {
+    fn union_namespace() {
         let input_test = vec![Namespace {
             enums: Vec::new(),
             structs: vec![Struct {

--- a/src/generator/go/mod.rs
+++ b/src/generator/go/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use handlebars::{Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext, RenderError};
+use handlebars::Handlebars;
 use std::collections::HashMap;
 
 static HEADER: &str = r#"
@@ -37,20 +37,17 @@ static TYPEDEFS_T: &str = r#"
 
 {{#each ns.typedefs as |td| ~}}
 {{#if td.def.array_size}}
-  {{#if td.def.fixed_array}}
-  // {{td.def.name}} generated typedef
-  type {{td.def.name}} {{#if (neqstr td.def.type_name) }}[{{td.def.array_size}}]{{/if}}{{#if (eqstruct td.def.type_name)}}*{{/if}}{{td.def.type_name}}
-  // XDRMaxSize implements the Sized interface for {{td.def.name}}
-  func (s {{td.def.name}}) XDRMaxSize() int {
-    return {{td.def.array_size}}
-  }
-  {{else}}
-  // {{td.def.name}} generated typedef
-  type {{td.def.name}} {{#if (neqstr td.def.type_name) }}[]{{#if (eqstruct td.def.type_name)}}*{{/if}}{{/if}}{{td.def.type_name}}
-  {{/if}}
+{{#if td.def.fixed_array}}
+// {{td.def.name}} generated typedef
+type {{td.def.name}} {{#if (neqstr td.def.type_name) }}[{{td.def.array_size}}]{{/if}}{{td.def.type_name}}
+// XDRMaxSize implements the Sized interface for {{td.def.name}}
+func (s {{td.def.name}}) XDRMaxSize() int {
+  return {{td.def.array_size}}
+}
 {{else}}
-  // {{td.def.name}} generated typedef
-  type {{td.def.name}} {{td.def.type_name}}
+// {{td.def.name}} generated typedef
+type {{td.def.name}} {{#if (neqstr td.def.type_name) }}[]{{/if}}{{td.def.type_name}}
+{{/if}}
 {{/if}}
 
 // MarshalBinary implements encoding.BinaryMarshaler.
@@ -89,17 +86,17 @@ type {{st.name}} struct {
     {{prop.name}} string `json:"{{lower prop.name}}"`
   {{/if}}
 {{else}} {{#if prop.fixed_array}}
-  {{prop.name}} [{{prop.array_size}}]{{#if (eqstruct prop.type_name)}}*{{/if}}{{prop.type_name}} `json:"{{lower prop.name}}"`
+  {{prop.name}} [{{prop.array_size}}]{{prop.type_name}} `json:"{{lower prop.name}}"`
 {{else}} {{#if prop.array_size}}
   {{#if (ne prop.array_size 2147483647)}}
-    {{prop.name}} []{{#if (eqstruct prop.type_name)}}*{{/if}}{{prop.type_name}} `xdrmaxsize:"{{prop.array_size}}" json:"{{lower prop.name}}"`
+    {{prop.name}} []{{prop.type_name}} `xdrmaxsize:"{{prop.array_size}}" json:"{{lower prop.name}}"`
   {{else}}
-    {{prop.name}} []{{#if (eqstruct prop.type_name)}}*{{/if}}{{prop.type_name}} `json:"{{lower prop.name}}"`
+    {{prop.name}} []{{prop.type_name}} `json:"{{lower prop.name}}"`
   {{/if}}
 {{else}} {{#if (bignum prop.type_name)}}
   {{prop.name}} {{prop.type_name}} `json:"{{lower prop.name}},string"`
 {{else}}
-  {{prop.name}} {{#if (eqstruct prop.type_name)}}*{{/if}}{{prop.type_name}} `json:"{{lower prop.name}}"`
+  {{prop.name}} {{prop.type_name}} `json:"{{lower prop.name}}"`
 {{/if}}
 {{/if}}
 {{/if}}
@@ -156,7 +153,7 @@ func (s {{enum.name}}) ValidEnum(v int32) bool {
 }
 // String returns the name of `e`
 func (s {{enum.name}}) String() string {
-  name := {{enum.name}}Map[int32(s)]
+  name, _ := {{enum.name}}Map[int32(s)]
   return name
 }
 
@@ -193,7 +190,7 @@ type {{uni.name}} struct{
     {{#if (eqstr case.ret_type.type_name)}}
         {{case.ret_type.name}} *{{case.ret_type.type_name}}
     {{else}} {{#if case.ret_type.array_size}}
-        {{case.ret_type.name}} []{{#if (eqstruct case.ret_type.type_name)}}*{{/if}}{{case.ret_type.type_name}}
+        {{case.ret_type.name}} *[]{{case.ret_type.type_name}}
     {{else}}
         {{case.ret_type.name}} *{{case.ret_type.type_name}}
     {{/if}} {{/if}}
@@ -219,7 +216,7 @@ switch {{uni.switch.enum_type}}(sw) {
 return "-", false
 }
 
-// New{{uni.name}} creates a new {{uni.name}}.
+// New{{uni.name}} creates a new  {{uni.name}}.
 func New{{uni.name}}(aType {{uni.switch.enum_type}}, value interface{}) (result {{uni.name}}, err error) {
   result.Type = aType
 switch {{uni.enum_type}}(aType) {
@@ -229,7 +226,7 @@ switch {{uni.enum_type}}(aType) {
     {{#if (eqstr case.ret_type.type_name)}}
         tv, ok := value.({{case.ret_type.type_name}})
     {{else}}{{#if case.ret_type.array_size}}
-        tv, ok := value.([]{{#if (eqstruct case.ret_type.type_name)}}*{{/if}}{{case.ret_type.type_name}})
+        tv, ok := value.([]{{case.ret_type.type_name}})
     {{else}}
         tv, ok := value.({{case.ret_type.type_name}})
     {{/if}} {{/if}}
@@ -237,7 +234,7 @@ switch {{uni.enum_type}}(aType) {
         err = fmt.Errorf("invalid value, must be {{case.ret_type}}")
         return
     }
-    result.{{case.ret_type.name}} = {{#unless case.ret_type.array_size}}&{{/unless}}tv
+    result.{{case.ret_type.name}} = &tv
 {{/if}}
 {{/each~}}
 }
@@ -249,8 +246,8 @@ switch {{uni.enum_type}}(aType) {
 // Must{{case.ret_type.name}} retrieves the {{case.ret_type.name}} value from the union,
 // panicing if the value is not set.
     {{#if (eqstr case.ret_type.type_name)}} func (u {{uni.name}}) Must{{case.ret_type.name}}() {{case.ret_type.type_name}} {
-    {{else}}{{#if case.ret_type.array_size}} func (u {{uni.name}}) Must{{case.ret_type.name}}() []{{#if (eqstruct case.ret_type.type_name)}}*{{/if}}{{case.ret_type.type_name}} {
-    {{else}} func (u {{uni.name}}) Must{{case.ret_type.name}}() {{#if (eqstruct case.ret_type.type_name)}}*{{/if}}{{case.ret_type.type_name}} {
+    {{else}}{{#if case.ret_type.array_size}} func (u {{uni.name}}) Must{{case.ret_type.name}}() []{{case.ret_type.type_name}} {
+    {{else}} func (u {{uni.name}}) Must{{case.ret_type.name}}() {{case.ret_type.type_name}} {
     {{/if}} {{/if}}
   val, ok := u.Get{{case.ret_type.name}}()
   if !ok {
@@ -263,13 +260,13 @@ switch {{uni.enum_type}}(aType) {
 // Get{{case.ret_type.name}} retrieves the {{case.ret_type.name}} value from the union,
 // returning ok if the union's switch indicated the value is valid.
     {{#if (eqstr case.ret_type.type_name)}} func (u {{uni.name}}) Get{{case.ret_type.name}}() (result {{case.ret_type.type_name}}, ok bool) {
-    {{else}}{{#if case.ret_type.array_size}} func (u {{uni.name}}) Get{{case.ret_type.name}}() (result []{{#if (eqstruct case.ret_type.type_name)}}*{{/if}}{{case.ret_type.type_name}}, ok bool) {
-    {{else}} func (u {{uni.name}}) Get{{case.ret_type.name}}() (result {{#if (eqstruct case.ret_type.type_name)}}*{{/if}}{{case.ret_type.type_name}}, ok bool) {
+    {{else}}{{#if case.ret_type.array_size}} func (u {{uni.name}}) Get{{case.ret_type.name}}() (result []{{case.ret_type.type_name}}, ok bool) {
+    {{else}} func (u {{uni.name}}) Get{{case.ret_type.name}}() (result {{case.ret_type.type_name}}, ok bool) {
     {{/if}}{{/if}}
   armName, _ := u.ArmForSwitch(int32(u.Type))
 
   if armName == "{{case.ret_type.name}}" {
-    result = {{#unless case.ret_type.array_size}}{{#unless (eqstruct case.ret_type.type_name)}}*{{/unless}}{{/unless}}u.{{case.ret_type.name}}
+    result = *u.{{case.ret_type.name}}
     ok = true
   }
 
@@ -332,7 +329,7 @@ func (u *{{uni.name}}) UnmarshalJSON(data []byte) error {
       {{#if (eqstr case.ret_type.type_name)}}
         {{case.ret_type.name}} {{case.ret_type.type_name}} `json:"data"`
       {{else}} {{#if case.ret_type.array_size}}
-          {{case.ret_type.name}} []{{#if (eqstruct case.ret_type.type_name)}}*{{/if}}{{case.ret_type.type_name}} `json:"data"`
+          {{case.ret_type.name}} []{{case.ret_type.type_name}} `json:"data"`
                {{else}}
           {{case.ret_type.name}} {{case.ret_type.type_name}} `json:"data"`
                {{/if}}
@@ -342,7 +339,7 @@ func (u *{{uni.name}}) UnmarshalJSON(data []byte) error {
       if err != nil {
         return err
       }
-      u.{{case.ret_type.name}} = {{#unless case.ret_type.array_size}}&{{/unless}}response.{{case.ret_type.name}}
+      u.{{case.ret_type.name}} = &response.{{case.ret_type.name}}
     {{/if}}
   {{/each~}}
   default:
@@ -425,52 +422,10 @@ fn to_first_lower(value: &str) -> String {
     }
 }
 
-// implement by a structure impls HelperDef
-#[derive(Clone)]
-struct StructHelper {
-    struct_map: HashMap<String, bool>,
-}
-
-impl HelperDef for StructHelper {
-    fn call<'reg: 'rc, 'rc>(
-        &self,
-        h: &Helper<'reg, 'rc>,
-        _: &'reg Handlebars,
-        _: &'rc Context,
-        _: &mut RenderContext<'reg, 'rc>,
-        out: &mut dyn Output,
-    ) -> HelperResult {
-        let param = h
-            .param(0)
-            .ok_or_else(|| RenderError::new("Param not found for helper \"eqstruct\""))?;
-
-        // Remove beginning and ending quote from json string to get key
-        let input = &param.value().to_string();
-        let key = &input[1..input.len() - 1];
-
-        if self.struct_map.contains_key(key) {
-            out.write("true")?;
-        }
-
-        Ok(())
-    }
-}
-
 impl CodeGenerator for GoGenerator {
     fn code(&self, namespaces: Vec<Namespace>) -> Result<String, &'static str> {
         let mut reg = Handlebars::new();
         let file_t = build_file_template();
-
-        // Get a map of struct names used
-        let mut struct_map: HashMap<String, bool> = HashMap::new();
-        for namespace in namespaces.clone() {
-            for struct_ in namespace.structs {
-                struct_map.insert(struct_.name, true);
-            }
-        }
-
-        let struct_helper = StructHelper { struct_map: struct_map };
-
         handlebars_helper!(neqstr: |x: str| x != "string");
         handlebars_helper!(eqstr: |x: str| x == "string");
         handlebars_helper!(bignum: |x: str| x == "uint64" || x =="int64");
@@ -478,7 +433,6 @@ impl CodeGenerator for GoGenerator {
         handlebars_helper!(lower: |x: str| to_first_lower(x));
         reg.register_helper("neqstr", Box::new(neqstr));
         reg.register_helper("eqstr", Box::new(eqstr));
-        reg.register_helper("eqstruct", Box::new(struct_helper));
         reg.register_helper("bignum", Box::new(bignum));
         reg.register_helper("isvoid", Box::new(isvoid));
         let processed_ns = process_namespaces(namespaces)?;
@@ -508,213 +462,91 @@ mod tests {
     fn typedef_namespace() {
         let input_test = vec![Namespace {
             enums: Vec::new(),
-            structs: vec![Struct {
-                name: String::from("TestStruct"),
-                props: vec![Def {
-                    name: String::from("stringTest"),
+            structs: Vec::new(),
+            typedefs: vec![Typedef {
+                def: Def {
+                    name: String::from("testt"),
                     type_name: String::from("string"),
                     array_size: 0,
                     fixed_array: false,
                     tag: String::new(),
-                }],
-                tag: String::new(),
+                },
             }],
-            typedefs: vec![
-                Typedef {
-                    def: Def {
-                        name: String::from("testt"),
-                        type_name: String::from("string"),
-                        array_size: 0,
-                        fixed_array: false,
-                        tag: String::new(),
-                    },
-                },
-                Typedef {
-                    def: Def {
-                        name: String::from("intDef"),
-                        type_name: String::from("int"),
-                        array_size: 0,
-                        fixed_array: false,
-                        tag: String::new(),
-                    },
-                },
-                Typedef {
-                    def: Def {
-                        name: String::from("structDef"),
-                        type_name: String::from("TestStruct"),
-                        array_size: 0,
-                        fixed_array: false,
-                        tag: String::new(),
-                    },
-                },
-                Typedef {
-                    def: Def {
-                        name: String::from("arrayDef"),
-                        type_name: String::from("int"),
-                        array_size: 5,
-                        fixed_array: false,
-                        tag: String::new(),
-                    },
-                },
-                Typedef {
-                    def: Def {
-                        name: String::from("fixedArrayDef"),
-                        type_name: String::from("int"),
-                        array_size: 5,
-                        fixed_array: true,
-                        tag: String::new(),
-                    },
-                },
-                Typedef {
-                    def: Def {
-                        name: String::from("structArrayDef"),
-                        type_name: String::from("TestStruct"),
-                        array_size: 5,
-                        fixed_array: false,
-                        tag: String::new(),
-                    },
-                },
-                Typedef {
-                    def: Def {
-                        name: String::from("fixedStructArrayDef"),
-                        type_name: String::from("TestStruct"),
-                        array_size: 5,
-                        fixed_array: true,
-                        tag: String::new(),
-                    },
-                },
-            ],
             unions: Vec::new(),
             name: String::from("test"),
         }];
         let res = GoGenerator {}.code(input_test);
         assert!(res.is_ok());
         let generated_code = res.unwrap();
-        println!("{}", generated_code);
         assert!(generated_code.contains("func (s Testt) MarshalBinary() ([]byte, error)"));
         assert!(generated_code.contains("func (s *Testt) UnmarshalBinary(inp []byte) error"));
-        assert!(generated_code.contains("type IntDef int32"));
-        assert!(generated_code.contains("type StructDef TestStruct"));
-        assert!(generated_code.contains("type ArrayDef []int32"));
-        assert!(generated_code.contains("type FixedArrayDef [5]int32"));
-        assert!(generated_code.contains("type StructArrayDef []*TestStruct"));
-        assert!(generated_code.contains("type FixedStructArrayDef [5]*TestStruct"));
     }
     #[test]
     fn struct_namespace() {
         let input_test = vec![Namespace {
             enums: Vec::new(),
             typedefs: Vec::new(),
-            structs: vec![
-                Struct {
-                    name: String::from("TestStruct"),
-                    props: vec![
-                        Def {
-                            name: String::from("stringTest"),
-                            type_name: String::from("string"),
-                            array_size: 0,
-                            fixed_array: false,
-                            tag: String::new(),
-                        },
-                        Def {
-                            name: String::from("BooleanTest"),
-                            type_name: String::from("boolean"),
-                            array_size: 0,
-                            fixed_array: false,
-                            tag: String::new(),
-                        },
-                        Def {
-                            name: String::from("float_test"),
-                            type_name: String::from("float"),
-                            array_size: 0,
-                            fixed_array: false,
-                            tag: String::new(),
-                        },
-                        Def {
-                            name: String::from("int_test"),
-                            type_name: String::from("int"),
-                            array_size: 0,
-                            fixed_array: false,
-                            tag: String::new(),
-                        },
-                        Def {
-                            name: String::from("unsigned_int_test"),
-                            type_name: String::from("unsigned int"),
-                            array_size: 0,
-                            fixed_array: false,
-                            tag: String::new(),
-                        },
-                        Def {
-                            name: String::from("hyper_test"),
-                            type_name: String::from("hyper"),
-                            array_size: 0,
-                            fixed_array: false,
-                            tag: String::new(),
-                        },
-                        Def {
-                            name: String::from("unsigned_hyper_test"),
-                            type_name: String::from("unsigned hyper"),
-                            array_size: 0,
-                            fixed_array: false,
-                            tag: String::new(),
-                        },
-                        Def {
-                            name: String::from("struct_test"),
-                            type_name: String::from("TestStruct2"),
-                            array_size: 0,
-                            fixed_array: false,
-                            tag: String::new(),
-                        },
-                        Def {
-                            name: String::from("array_test"),
-                            type_name: String::from("unsigned hyper"),
-                            array_size: 5,
-                            fixed_array: false,
-                            tag: String::new(),
-                        },
-                        Def {
-                            name: String::from("array_struct_test"),
-                            type_name: String::from("TestStruct2"),
-                            array_size: 5,
-                            fixed_array: false,
-                            tag: String::new(),
-                        },
-                        Def {
-                            name: String::from("fixed_array_test"),
-                            type_name: String::from("unsigned hyper"),
-                            array_size: 5,
-                            fixed_array: true,
-                            tag: String::new(),
-                        },
-                        Def {
-                            name: String::from("fixed_array_struct_test"),
-                            type_name: String::from("TestStruct2"),
-                            array_size: 5,
-                            fixed_array: true,
-                            tag: String::new(),
-                        },
-                    ],
-                    tag: String::new(),
-                },
-                Struct {
-                    name: String::from("TestStruct2"),
-                    props: vec![Def {
+            structs: vec![Struct {
+                name: String::from("TestStruct"),
+                props: vec![
+                    Def {
                         name: String::from("stringTest"),
                         type_name: String::from("string"),
                         array_size: 0,
                         fixed_array: false,
                         tag: String::new(),
-                    }],
-                    tag: String::new(),
-                },
-            ],
+                    },
+                    Def {
+                        name: String::from("BooleanTest"),
+                        type_name: String::from("boolean"),
+                        array_size: 0,
+                        fixed_array: false,
+                        tag: String::new(),
+                    },
+                    Def {
+                        name: String::from("float_test"),
+                        type_name: String::from("float"),
+                        array_size: 0,
+                        fixed_array: false,
+                        tag: String::new(),
+                    },
+                    Def {
+                        name: String::from("int_test"),
+                        type_name: String::from("int"),
+                        array_size: 0,
+                        fixed_array: false,
+                        tag: String::new(),
+                    },
+                    Def {
+                        name: String::from("unsigned_int_test"),
+                        type_name: String::from("unsigned int"),
+                        array_size: 0,
+                        fixed_array: false,
+                        tag: String::new(),
+                    },
+                    Def {
+                        name: String::from("hyper_test"),
+                        type_name: String::from("hyper"),
+                        array_size: 0,
+                        fixed_array: false,
+                        tag: String::new(),
+                    },
+                    Def {
+                        name: String::from("unsigned_hyper_test"),
+                        type_name: String::from("unsigned hyper"),
+                        array_size: 0,
+                        fixed_array: false,
+                        tag: String::new(),
+                    },
+                ],
+                tag: String::new(),
+            }],
             unions: Vec::new(),
             name: String::from("test"),
         }];
         let res = GoGenerator {}.code(input_test);
         assert!(res.is_ok());
         let generated_code = res.unwrap();
-        println!("{}", generated_code);
         assert!(generated_code.contains("type TestStruct struct {"));
         assert!(generated_code.contains("StringTest string `json:\"stringTest\"`"));
         assert!(generated_code.contains("BooleanTest bool `json:\"booleanTest\"`"));
@@ -723,109 +555,5 @@ mod tests {
         assert!(generated_code.contains("Unsigned_int_test uint32 `json:\"unsigned_int_test\"`"));
         assert!(generated_code.contains("Hyper_test int64 `json:\"hyper_test,string\"`"));
         assert!(generated_code.contains("Unsigned_hyper_test uint64 `json:\"unsigned_hyper_test,string\"`"));
-        assert!(generated_code.contains("Struct_test *TestStruct2 `json:\"struct_test\"`"));
-        assert!(generated_code.contains("Array_test []uint64 `xdrmaxsize:\"5\" json:\"array_test\"`"));
-        assert!(generated_code.contains("Array_struct_test []*TestStruct2 `xdrmaxsize:\"5\" json:\"array_struct_test\"`"));
-        assert!(generated_code.contains("Fixed_array_test [5]uint64 `json:\"fixed_array_test\"`"));
-        assert!(generated_code.contains("Fixed_array_struct_test [5]*TestStruct2 `json:\"fixed_array_struct_test\"`"));
-    }
-    #[test]
-    fn typedef_union() {
-        let input_test = vec![Namespace {
-            enums: Vec::new(),
-            structs: vec![Struct {
-                name: String::from("TestStruct"),
-                props: vec![Def {
-                    name: String::from("stringTest"),
-                    type_name: String::from("string"),
-                    array_size: 0,
-                    fixed_array: false,
-                    tag: String::new(),
-                }],
-                tag: String::new(),
-            }],
-            typedefs: Vec::new(),
-            unions: vec![Union {
-                name: String::from("TestUnion"),
-                switch: Switch {
-                    enum_name: String::from("Type"),
-                    enum_type: String::from("enumType"),
-                    cases: vec![
-                        Case {
-                            value: String::from("ONE"),
-                            ret_type: Def {
-                                name: String::from("stringTest"),
-                                type_name: String::from("string"),
-                                array_size: 0,
-                                fixed_array: false,
-                                tag: String::new(),
-                            },
-                        },
-                        Case {
-                            value: String::from("TWO"),
-                            ret_type: Def {
-                                name: String::from("structTest"),
-                                type_name: String::from("TestStruct"),
-                                array_size: 0,
-                                fixed_array: false,
-                                tag: String::new(),
-                            },
-                        },
-                        Case {
-                            value: String::from("THREE"),
-                            ret_type: Def {
-                                name: String::from("arrayTest"),
-                                type_name: String::from("int"),
-                                array_size: 5,
-                                fixed_array: false,
-                                tag: String::new(),
-                            },
-                        },
-                        Case {
-                            value: String::from("FOUR"),
-                            ret_type: Def {
-                                name: String::from("arrayStructTest"),
-                                type_name: String::from("TestStruct"),
-                                array_size: 5,
-                                fixed_array: false,
-                                tag: String::new(),
-                            },
-                        },
-                    ],
-                },
-            }],
-            name: String::from("test"),
-        }];
-        let res = GoGenerator {}.code(input_test);
-        assert!(res.is_ok());
-        let generated_code = res.unwrap();
-        println!("{}", generated_code);
-        assert!(generated_code.contains("StringTest *string"));
-        assert!(generated_code.contains("result = *u.StringTest"));
-        assert!(generated_code.contains("u.StringTest = &response.StringTest"));
-        assert!(generated_code.contains("func (u TestUnion) MustStringTest() string {"));
-        assert!(generated_code.contains("func (u TestUnion) GetStringTest() (result string, ok bool) {"));
-        assert!(generated_code.contains("result.StringTest = &tv"));
-
-        assert!(generated_code.contains("StructTest *TestStruct"));
-        assert!(generated_code.contains("result = u.StructTest"));
-        assert!(generated_code.contains("u.StructTest = &response.StructTest"));
-        assert!(generated_code.contains("func (u TestUnion) MustStructTest() *TestStruct {"));
-        assert!(generated_code.contains("func (u TestUnion) GetStructTest() (result *TestStruct, ok bool) {"));
-        assert!(generated_code.contains("result.StructTest = &tv"));
-
-        assert!(generated_code.contains("ArrayTest []int32"));
-        assert!(generated_code.contains("result = u.ArrayTest"));
-        assert!(generated_code.contains("u.ArrayTest = response.ArrayTest"));
-        assert!(generated_code.contains("func (u TestUnion) MustArrayTest() []int32 {"));
-        assert!(generated_code.contains("func (u TestUnion) GetArrayTest() (result []int32, ok bool) {"));
-        assert!(generated_code.contains("result.ArrayTest = tv"));
-
-        assert!(generated_code.contains("ArrayStructTest []*TestStruct"));
-        assert!(generated_code.contains("result = u.ArrayStructTest"));
-        assert!(generated_code.contains("u.ArrayStructTest = response.ArrayStructTest"));
-        assert!(generated_code.contains("func (u TestUnion) MustArrayStructTest() []*TestStruct {"));
-        assert!(generated_code.contains("func (u TestUnion) GetArrayStructTest() (result []*TestStruct, ok bool) {"));
-        assert!(generated_code.contains("result.ArrayStructTest = tv"));
     }
 }

--- a/src/generator/go/mod.rs
+++ b/src/generator/go/mod.rs
@@ -153,7 +153,7 @@ func (s {{enum.name}}) ValidEnum(v int32) bool {
 }
 // String returns the name of `e`
 func (s {{enum.name}}) String() string {
-  name, _ := {{enum.name}}Map[int32(s)]
+  name := {{enum.name}}Map[int32(s)]
   return name
 }
 
@@ -216,7 +216,7 @@ switch {{uni.switch.enum_type}}(sw) {
 return "-", false
 }
 
-// New{{uni.name}} creates a new  {{uni.name}}.
+// New{{uni.name}} creates a new {{uni.name}}.
 func New{{uni.name}}(aType {{uni.switch.enum_type}}, value interface{}) (result {{uni.name}}, err error) {
   result.Type = aType
 switch {{uni.enum_type}}(aType) {

--- a/src/generator/rust/mod.rs
+++ b/src/generator/rust/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use handlebars::{Handlebars, Helper, Context, RenderContext, Output, HelperResult};
+use handlebars::{Context, Handlebars, Helper, HelperResult, Output, RenderContext};
 
 static HEADER: &str = r#"
 #![allow(non_snake_case)]
@@ -136,7 +136,7 @@ fn build_file_template() -> String {
 }
 
 pub struct RustGenerator {
-  pub include_macro: bool,
+    pub include_macro: bool,
 }
 
 fn process_namespaces(namespaces: Vec<Namespace>) -> Result<Vec<Namespace>, &'static str> {
@@ -163,14 +163,20 @@ impl CodeGenerator for RustGenerator {
         reg.register_helper("neqstr", Box::new(neqstr));
         reg.register_helper("eqstr", Box::new(eqstr));
         reg.register_helper("isvoid", Box::new(isvoid));
-        reg.register_helper("macro-use", 
-          Box::new(|_h: &Helper, _r: &Handlebars, _: &Context, _rc: &mut RenderContext, out: &mut dyn Output| -> HelperResult {
-            if self.include_macro {
-            out.write("#[macro_use]
-extern crate xdr_rs_serialize_derive;")?;
-            }
-            Ok(())
-        }));
+        reg.register_helper(
+            "macro-use",
+            Box::new(
+                |_h: &Helper, _r: &Handlebars, _: &Context, _rc: &mut RenderContext, out: &mut dyn Output| -> HelperResult {
+                    if self.include_macro {
+                        out.write(
+                            "#[macro_use]
+extern crate xdr_rs_serialize_derive;",
+                        )?;
+                    }
+                    Ok(())
+                },
+            ),
+        );
         let processed_ns = process_namespaces(namespaces)?;
         let result = reg.render_template(file_t.into_boxed_str().as_ref(), &processed_ns).unwrap();
 
@@ -190,7 +196,7 @@ mod tests {
             unions: Vec::new(),
             name: String::from("test"),
         }];
-        let res = RustGenerator {include_macro: false}.code(input_test);
+        let res = RustGenerator { include_macro: false }.code(input_test);
         assert!(res.is_ok());
         let generated_code = res.unwrap();
         println!("{}", generated_code);
@@ -199,18 +205,20 @@ mod tests {
 
     #[test]
     fn with_macro() {
-      let input_test = vec![Namespace {
-          enums: Vec::new(),
-          structs: Vec::new(),
-          typedefs: Vec::new(),
-          unions: Vec::new(),
-          name: String::from("test"),
-      }];
-      let res = RustGenerator {include_macro: true}.code(input_test);
-      assert!(res.is_ok());
-      let generated_code = res.unwrap();
-      println!("{}", generated_code);
-      assert!(generated_code.contains("#[macro_use]
-extern crate xdr_rs_serialize_derive;"));
-  }
+        let input_test = vec![Namespace {
+            enums: Vec::new(),
+            structs: Vec::new(),
+            typedefs: Vec::new(),
+            unions: Vec::new(),
+            name: String::from("test"),
+        }];
+        let res = RustGenerator { include_macro: true }.code(input_test);
+        assert!(res.is_ok());
+        let generated_code = res.unwrap();
+        println!("{}", generated_code);
+        assert!(generated_code.contains(
+            "#[macro_use]
+extern crate xdr_rs_serialize_derive;"
+        ));
+    }
 }

--- a/src/generator/rust/mod.rs
+++ b/src/generator/rust/mod.rs
@@ -1,11 +1,10 @@
 use super::*;
-use handlebars::Handlebars;
+use handlebars::{Handlebars, Helper, Context, RenderContext, Output, HelperResult};
 
 static HEADER: &str = r#"
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
-#[macro_use]
-extern crate xdr_rs_serialize_derive;
+{{macro-use}}
 #[allow(unused_imports)]
 use xdr_rs_serialize::de::{
     read_fixed_array, read_fixed_array_json, read_fixed_opaque, read_fixed_opaque_json,
@@ -136,7 +135,9 @@ fn build_file_template() -> String {
     format!("{}{}{}{}{}{}", HEADER, TYPEDEFS_T, STRUCTS_T, ENUM_T, UNION_T, FOOTER)
 }
 
-pub struct RustGenerator {}
+pub struct RustGenerator {
+  pub include_macro: bool,
+}
 
 fn process_namespaces(namespaces: Vec<Namespace>) -> Result<Vec<Namespace>, &'static str> {
     let mut type_map = HashMap::new();
@@ -162,9 +163,54 @@ impl CodeGenerator for RustGenerator {
         reg.register_helper("neqstr", Box::new(neqstr));
         reg.register_helper("eqstr", Box::new(eqstr));
         reg.register_helper("isvoid", Box::new(isvoid));
+        reg.register_helper("macro-use", 
+          Box::new(|_h: &Helper, _r: &Handlebars, _: &Context, _rc: &mut RenderContext, out: &mut dyn Output| -> HelperResult {
+            if self.include_macro {
+            out.write("#[macro_use]
+extern crate xdr_rs_serialize_derive;")?;
+            }
+            Ok(())
+        }));
         let processed_ns = process_namespaces(namespaces)?;
         let result = reg.render_template(file_t.into_boxed_str().as_ref(), &processed_ns).unwrap();
 
         return Ok(result);
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn without_macro() {
+        let input_test = vec![Namespace {
+            enums: Vec::new(),
+            structs: Vec::new(),
+            typedefs: Vec::new(),
+            unions: Vec::new(),
+            name: String::from("test"),
+        }];
+        let res = RustGenerator {include_macro: false}.code(input_test);
+        assert!(res.is_ok());
+        let generated_code = res.unwrap();
+        println!("{}", generated_code);
+        assert!(!generated_code.contains("#[macro_use]"));
+    }
+
+    #[test]
+    fn with_macro() {
+      let input_test = vec![Namespace {
+          enums: Vec::new(),
+          structs: Vec::new(),
+          typedefs: Vec::new(),
+          unions: Vec::new(),
+          name: String::from("test"),
+      }];
+      let res = RustGenerator {include_macro: true}.code(input_test);
+      assert!(res.is_ok());
+      let generated_code = res.unwrap();
+      println!("{}", generated_code);
+      assert!(generated_code.contains("#[macro_use]
+extern crate xdr_rs_serialize_derive;"));
+  }
 }

--- a/src/generator/rust/mod.rs
+++ b/src/generator/rust/mod.rs
@@ -24,7 +24,7 @@ use std::io::Write;
 extern crate json;
 
 {{#each this as |ns| ~}}
-// Namspace start {{ns.name}}
+// Namespace start {{ns.name}}
 "#;
 
 static TYPEDEFS_T: &str = r#"
@@ -128,7 +128,7 @@ impl Default for {{uni.name}} {
 "#;
 
 static FOOTER: &str = r#"
-// Namspace end {{ns.name}}
+// Namespace end {{ns.name}}
 {{/each~}}"#;
 
 fn build_file_template() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,10 @@ struct Opt {
     /// Output language
     #[structopt(short = "l", long = "language")]
     language: Option<String>,
+
+    /// Include macro_use for xdr_rs_serialize_derive crate in Rust
+    #[structopt(short = "m", long = "macro")]
+    include_macro: bool,
 }
 
 fn main() -> io::Result<()> {
@@ -55,11 +59,15 @@ fn main() -> io::Result<()> {
 
     let namespaces = ast::build_namespaces(buffer).unwrap();
 
+    let rust_generator;
     let generator: &dyn generator::CodeGenerator = match opt.language {
         Some(language) => match language.as_ref() {
             "go" => &generator::go::GoGenerator {},
             "js" => &generator::js::JsGenerator {},
-            "rust" => &generator::rust::RustGenerator {},
+            "rust" => {
+                rust_generator = generator::rust::RustGenerator {include_macro: opt.include_macro};
+                &rust_generator
+            },
             "commonjs" => &generator::commonjs::CommonJsGenerator {},
             _ => panic!("Invalid language selection. Options: go, js, rust commonjs"),
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,9 +65,11 @@ fn main() -> io::Result<()> {
             "go" => &generator::go::GoGenerator {},
             "js" => &generator::js::JsGenerator {},
             "rust" => {
-                rust_generator = generator::rust::RustGenerator {include_macro: opt.include_macro};
+                rust_generator = generator::rust::RustGenerator {
+                    include_macro: opt.include_macro,
+                };
                 &rust_generator
-            },
+            }
             "commonjs" => &generator::commonjs::CommonJsGenerator {},
             _ => panic!("Invalid language selection. Options: go, js, rust commonjs"),
         },


### PR DESCRIPTION
# Description

In order to preserve the Binary Marshal format of XDR Structs this update reverts the change to storing internal struct fields as pointers.  

This is not a full revert of the previous commit.  Instead this just undoes the specific XDR Go generation change that caused the broken marshal.  The handlebars dependency has still been updated along with a few code generation fixes in Go and additional Test cases.

Also added new command line flag for Rust language generation to specify if the macro_use extern should be included in the Header.  Since loading macros can only be done in the crate root this should not be included in the generated file by default.  Boolean flag must be set to include the lines:

```
-m, --macro      Include macro_use for xdr_rs_serialize_derive crate in Rust
```