### PR TITLE
fix(commonjs): register escape function for common js to prevent escape character encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,7 +445,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xdr-codegen"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "handlebars",
  "pest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xdr-codegen"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "XDR code generation"
 license = "MIT"

--- a/src/generator/commonjs/mod.rs
+++ b/src/generator/commonjs/mod.rs
@@ -152,6 +152,7 @@ impl CodeGenerator for CommonJsGenerator {
         handlebars_helper!(isvoid: |x: str| x == "");
         reg.register_helper("isvoid", Box::new(isvoid));
         reg.register_helper("typeconv", Box::new(typeconv));
+        reg.register_escape_fn(|s| s.into());
         let result = reg.render_template(file_t.into_boxed_str().as_ref(), &processed).unwrap();
 
         return Ok(result);


### PR DESCRIPTION
# Description

After the update to the latest handlerbars version the CodeGenerator for JavaScript had to be updated to register an empty escape function to prevent quotes and other special characters from being escaped.  

This update adds the register for commonJS as well.

Example line without the registered escape function:
```
return new _xdrJsSerialize.default.Str(&#x27;&#x27;, 100);
```

The correct version, which is generated with the escape function registered:
```
return new _xdrJsSerialize.default.Str('', 100);
```